### PR TITLE
Update arrow-cpp.rb

### DIFF
--- a/Formula/arrow-cpp.rb
+++ b/Formula/arrow-cpp.rb
@@ -22,21 +22,20 @@ class ArrowCpp < Formula
     mkdir build_type.downcase
     chdir build_type.downcase
     system "cmake", "-D", "CMAKE_BUILD_TYPE=#{build_type}", "-D", "CMAKE_INSTALL_PREFIX:PATH=#{prefix}", ".."
-    system "make unittest"
+    system "make", "unittest"
     system "make", "install"
   end
 
   test do
     (testpath/"test.cpp").write <<-EOS.undent
     #include "arrow/api.h"
-
     int main(void)
     {
       arrow::Int64Builder builder(arrow::default_memory_pool(), arrow::int64());
       return 0;
     }
     EOS
-    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{prefix}/include", "-L#{lib}", "-larrow", "-o", "test"
+    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-larrow", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
多分この状態で
`brew audit --strict`がパスしてると思います。
もし
`* C: 42: col 1: 1 trailing blank lines detected.`
って言われたらファイル末尾の改行を消してください。